### PR TITLE
Fixed disappearing image bug upon edit

### DIFF
--- a/app/src/main/java/com/example/inventory/AddItemFragment.kt
+++ b/app/src/main/java/com/example/inventory/AddItemFragment.kt
@@ -141,6 +141,7 @@ class AddItemFragment : Fragment() {
             binding.imageView.visibility = View.GONE
         } else {
             binding.imageView.visibility = View.VISIBLE
+            imageByte = item.imageByte
         }
 
     }


### PR DESCRIPTION
Fixed an issue where images would disappear upon editing them

Cause: Upon loading the 'edit item' page, the variable storing the image is set to 0 and not updated according to the data in the database

Fix: Update the value of the variable based on the database entry. 1 line fix: `imageByte = item.imageByte`

Testing: I manually tested all the edge cases I could come up with and it works fine now