### PR TITLE
Hotfix: Can now modify which image you uploaded, fixed padding issue

### DIFF
--- a/app/src/main/java/com/example/inventory/AddItemFragment.kt
+++ b/app/src/main/java/com/example/inventory/AddItemFragment.kt
@@ -28,6 +28,7 @@ import android.os.Bundle
 import android.provider.MediaStore
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -259,7 +260,7 @@ class AddItemFragment : Fragment() {
         if (resultCode == RESULT_OK && (requestCode == pickImage || requestCode == REQUEST_IMAGE_CAPTURE)) {
 
             // For processing the gallery-retrieved image
-            if (resultCode == RESULT_OK && requestCode == pickImage) {
+            if (requestCode == pickImage) {
                 imagePath = data?.data
                 imageBitmap = if (Build.VERSION.SDK_INT >= 28) {
                     val source =
@@ -269,12 +270,13 @@ class AddItemFragment : Fragment() {
                     MediaStore.Images.Media.getBitmap(requireActivity().contentResolver, imagePath!!)
                 }
 
-                // For processing the camera image
-            } else if (resultCode == RESULT_OK && requestCode == REQUEST_IMAGE_CAPTURE) {
+            // For processing the camera image
+            } else if (requestCode == REQUEST_IMAGE_CAPTURE) {
                 imageBitmap = data?.extras?.get("data") as Bitmap
             }
 
             binding.imageView.setImageBitmap(imageBitmap)
+            bos = ByteArrayOutputStream();
             imageBitmap?.compress(Bitmap.CompressFormat.JPEG, 33, bos)
             imageByte = bos?.toByteArray();
             binding.imageView.visibility = View.VISIBLE

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -22,15 +22,17 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingBottom="32dp"
+        android:clipToPadding="false"
         android:layout_margin="@dimen/margin">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/name_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin"
             android:hint="Ingredient Name"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -64,11 +66,11 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/label_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin"
             android:hint="Select a label"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/expiry_date_label">
@@ -77,19 +79,20 @@
                 android:id="@+id/label"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="none"/>
+                android:inputType="none" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
+            android:id="@+id/quantity_container"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin"
             android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@+id/imageView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/label_label"
-            app:layout_constraintBottom_toTopOf="@+id/imageView">
+            app:layout_constraintTop_toBottomOf="@+id/label_label">
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/quantity_label"
@@ -108,18 +111,18 @@
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/unit_label"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                android:layout_weight="1"
                 android:layout_marginLeft="10dp"
+                android:layout_weight="1"
                 android:hint="Unit (optional)">
 
                 <AutoCompleteTextView
                     android:id="@+id/unit"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="none"/>
+                    android:inputType="none" />
             </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>
@@ -136,7 +139,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/quantity_label"
+            app:layout_constraintTop_toBottomOf="@+id/quantity_container"
             app:layout_constraintVertical_bias="0.0"
             app:srcCompat="@drawable/baseline_image_search_24" />
 
@@ -146,10 +149,10 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin"
+            android:drawableLeft="@drawable/baseline_photo_camera_24"
             android:text="@string/take_photo"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:drawableLeft="@drawable/baseline_photo_camera_24"
             app:layout_constraintTop_toBottomOf="@id/imageView" />
 
         <Button
@@ -157,11 +160,11 @@
             style="?attr/materialButtonOutlinedStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin"
+            android:layout_marginTop="8dp"
+            android:drawableLeft="@drawable/baseline_image_search_24"
             android:text="@string/upload"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:drawableLeft="@drawable/baseline_image_search_24"
             app:layout_constraintTop_toBottomOf="@id/take_photo" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="add_new_item">Add new item</string>
     <string name="select_label">Select Label</string>
     <string name="upload">Upload Photo</string>
-    <string name="take_photo">Take Photo</string>
+    <string name="take_photo">Take a Photo</string>
     <string name="notify">Notify</string>
     <string name="channel_name">Expirations</string>
     <string name="channel_description">Notification channel for ingredient expiry messages</string>


### PR DESCRIPTION
Previously when you uploaded an image and then uploaded/captured another photo, the first one would be the one stored in the database rather than the most recent one

Additionally, tall photos forced the 'Save' button out of the screen

This PR fixes both. I didn't notice any other bugs or room for improvement for the camera tool aside from maybe UI changes